### PR TITLE
Correct capitalization for already capitalized pristine words

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ You're probably sitting there right now thinking, "My project would be so much b
 I was thinking the same thing too (about your project I mean). So I wrote this package for you.
 
 # Installation
-npm install pig-latin
+    npm install pig-latin
 
 # Usage
 
-We're not messing around here! This package includes:
+Tired of pig-latin packages that don't actually work? We're not messing around here. This package includes:
 
 - ACCURATE translation of words that start with vowels (with options, because some of you are crazy)
 - ACCURATE dealing with punctuation (mostly -- I'm sure if you really tried you could break it)
@@ -57,3 +57,7 @@ piglatin("help! help! i can't get up!", {capitalize: true})
 
 => 'Elphay! Elphay! Iway antcay etgay upway!'
 ```
+
+# Items to note
+
+- Does not support dashes. Those will be removed and replaced with commas.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+You're probably sitting there right now thinking, "My project would be so much better if the text were in a childish pseudo-language that is difficult to understand."
+
+I was thinking the same thing too (about your project I mean). So I wrote this package for you.
+
+# Installation
+npm install pig-latin
+
+# Usage
+
+We're not messing around here! This package includes:
+
+- ACCURATE translation of words that start with vowels (with options, because some of you are crazy)
+- ACCURATE dealing with punctuation (mostly -- I'm sure if you really tried you could break it)
+
+```javascript
+// Generic usage
+var piglatin = require('pig-latin')
+piglatin(text, options)
+```
+
+Let's see some examples:
+
+```javascript
+var piglatin = require('pig-latin')
+piglatin("help help, I can't get up!")
+
+=> 'elphay elphay, iway antcay etgay upway!'
+```
+
+# Options
+This module takes an options object, which currently supports two options:
+
+### vowelEnding
+Apparently everyone in the world uses a different ending for words that start with vowels. By default it is "-way", but you can set it to any string here you'd like.
+
+```javascript
+// Default
+piglatin("I am so happy inside")
+=> 'iway amway osay appyhay insideway'
+
+// Example 1 - not so crazy
+piglatin("I am so happy inside", {vowelEnding: 'ay'})
+=> 'iay amay osay appyhay insideay'
+
+// Example 2 - get as crazy as you want
+piglatin("I am so happy inside", {vowelEnding: 'juice'})
+=> 'ijuice amjuice osay appyhay insidejuice'
+
+// NOTE: this option only affects words that start with vowels
+```
+
+### Capitalize
+If you want to capitalize each sentence, set this to true.
+
+```javascript
+piglatin("help! help! i can't get up!", {capitalize: true})
+
+=> 'Elphay! Elphay! Iway antcay etgay upway!'
+```

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function piggyConsonantWord(word) {
 //////////////////////////////////////
 
 function prepForThePig(text) {
-    text = text.replace(/-|–|—/g, ", ")
+    text = text.replace(/-|–|—/g, ", ")     // Remove all dashes, because they are hecka hard to handle -- make them commas, instead
     text = text.split(' ')
     return text
 }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.1",
   "description": "Translate any English text to pig latin (accurately!), because you must be as bored as I am.",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/isaachess/pig-latin"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "pig-latin",
-  "version": "1.0.0",
-  "description": "Translate any English text to pig latin",
+  "version": "1.0.1",
+  "description": "Translate any English text to pig latin (accurately!), because you must be as bored as I am.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/isaachess/pig-latin"
+  },
+  "keywords": ["pig", "latin", "piglatin", "translate"],
   "author": "Isaac Hess <isaachess@gmail.com> (https://github.com/isaachess)",
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
Hey, @isaachess!

So I made it so already capitalized words will have their piggified first letters capitalized.
Their original first letters will be set to lowercase.

Passing `What are you having for lunch?` will return `Atwhay areway ouyay avinghay orfay unchlay?`.

It's closer to what it would've looked like before I modified the capitalization functionality.